### PR TITLE
fix: expand tilde character into user home directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "devspace"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arboard",
  "assert_cmd",
@@ -459,6 +459,7 @@ dependencies = [
  "color-eyre",
  "crossterm",
  "directories",
+ "expand-tilde",
  "git2",
  "lazy_static",
  "pretty_assertions",
@@ -547,6 +548,16 @@ name = "error-code"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
+name = "expand-tilde"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af42bffb99c712d4a07c17215b28e22f448b02e9d1481a8a5e05ebd837737f0c"
+dependencies = [
+ "home",
+ "thiserror",
+]
 
 [[package]]
 name = "eyre"
@@ -701,6 +712,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "icu_collections"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devspace"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Muzaffar Omer <muzaffar.omer@gmail.com>"]
 description = "Tool to create and manage git worktrees"
@@ -16,6 +16,7 @@ clap = { version = "4.5.29", features = ["derive", "env"] }
 color-eyre = "0.6.3"
 crossterm = "0.28.1"
 directories = "6.0.0"
+expand-tilde = "0.6.1"
 git2 = "0.20.0"
 lazy_static = "1.5.0"
 ratatui = "0.29.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use ratatui::{
 };
 
 use crate::{
-    cli::Args,
+    cli,
     components::{CreateWorktreeComponent, EventState, RepositoriesComponent, WorktreesComponent},
     git,
 };
@@ -21,13 +21,13 @@ pub struct App {
     worktrees_component: WorktreesComponent,
     repositories_component: RepositoriesComponent,
     create_worktree: CreateWorktreeComponent,
-    args: Args,
+    args: cli::Args,
     focus: Focus,
 }
 
 impl App {
     pub fn new() -> App {
-        let args = Args::new();
+        let args = cli::Args::new();
         let repositories = git::list_repositories(&args.repos_dir);
         let worktrees = git::worktrees_of_repositories(&repositories);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use expand_tilde;
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
@@ -24,6 +25,17 @@ pub struct Args {
 
 impl Args {
     pub fn new() -> Self {
-        Self::parse()
+        let mut args = Self::parse();
+        args.repos_dir = expand_tilde::expand_tilde(&args.repos_dir)
+            .expect("Could not expand the ~ in the repos_dir")
+            .to_str()
+            .expect("Could not convert the expanded repos_dir to a string")
+            .to_string();
+        args.worktrees_dir = expand_tilde::expand_tilde(&args.worktrees_dir)
+            .expect("Could not expand the ~ in the worktrees_dir")
+            .to_str()
+            .expect("Could not convert the expanded worktrees_dir to a string")
+            .to_string();
+        args
     }
 }


### PR DESCRIPTION
Handle the `~` properly in `DEVSPACE_WORKTREES_DIR` and `DEVSPACE_REPOS_DIR`