### PR TITLE
feat: support wayland clipboard and git fetch on demand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "windows-sys 0.48.0",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -218,6 +219,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
@@ -399,7 +406,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -450,8 +457,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "devspace"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arboard",
  "assert_cmd",
@@ -522,6 +540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af42bffb99c712d4a07c17215b28e22f448b02e9d1481a8a5e05ebd837737f0c"
 dependencies = [
  "home",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -583,6 +607,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -706,6 +736,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -887,6 +923,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,7 +1089,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1084,6 +1136,27 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1244,6 +1317,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1372,17 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.2",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1362,6 +1456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,7 +1531,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1490,8 +1593,21 @@ dependencies = [
  "bitflags 2.8.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1661,7 +1777,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -1673,11 +1789,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1794,6 +1930,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +2038,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.0.8",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+dependencies = [
+ "bitflags 2.8.0",
+ "rustix 1.0.8",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.8.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.8.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -2079,6 +2296,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b41773911497b18ca8553c3daaf8ec9fe9819caf93d451d3055f69de028adb"
+dependencies = [
+ "derive-new",
+ "libc",
+ "log",
+ "nix",
+ "os_pipe",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,7 +2334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 0.38.44",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devspace"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["Muzaffar Omer <muzaffar.omer@gmail.com>"]
 description = "Tool to create and manage git worktrees"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["git", "worktree", "workspace"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-arboard = "3.4.1"
+arboard = { version = "3.4.1", features = ["wayland-data-control"] }
 clap = { version = "4.5.29", features = ["derive", "env"] }
 color-eyre = "0.6.3"
 crossterm = "0.28.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ pub struct App {
 impl App {
     pub fn new() -> App {
         let args = cli::Args::new();
-        let repositories = git::list_repositories(&args.repos_dir);
+        let repositories = git::list_repositories(&args.repos_dir, args.run_fetch);
         let worktrees = git::worktrees_of_repositories(&repositories);
 
         let repositories_component = RepositoriesComponent::new(repositories);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,15 @@ pub struct Args {
         env = "DEVSPACE_REPOS_DIR"
     )]
     pub repos_dir: String,
+
+    /// Whether to run git fetch inside each repo. Default: false
+    #[arg(
+        short = 'f',
+        long = "run-fetch",
+        value_name = "BOOLEAN",
+        default_value_t = false
+    )]
+    pub run_fetch: bool,
 }
 
 impl Args {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ pub struct Args {
     )]
     pub repos_dir: String,
 
-    /// Whether to run git fetch inside each repo. Default: false
+    /// Whether to run git fetch for each repo. Default: false
     #[arg(
         short = 'f',
         long = "run-fetch",

--- a/src/components/worktrees.rs
+++ b/src/components/worktrees.rs
@@ -1,5 +1,5 @@
 use crate::git;
-use arboard::Clipboard;
+use arboard::{Clipboard, LinuxClipboardKind, SetExtLinux};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
@@ -135,20 +135,33 @@ impl WorktreesComponent {
     }
 
     fn copy_path_of_selected_worktree(&mut self) -> bool {
-        if let Ok(mut clipboard) = Clipboard::new() {
-            if let Some(path) = self.selected_worktree_path() {
-                if clipboard.set_text(path.clone()).is_ok() {
-                    debug!("Copied the path {} to clipboard", path);
-                    return true;
-                }
-                error!("Could not copy the path {} to clipboard.", path);
-            } else {
+        let path = match self.selected_worktree_path() {
+            Some(path) => path,
+            None => {
                 debug!("No worktree was selected. Nothing to copy to clipboard");
+                return false;
             }
-        } else {
-            error!("Could not access the clipboard.");
+        };
+
+        let mut clipboard = match Clipboard::new() {
+            Ok(cb) => cb,
+            Err(e) => {
+                error!("Could not access the clipboard: {}", e);
+                return false;
+            }
+        };
+
+        if let Err(e) = clipboard
+            .set()
+            .clipboard(LinuxClipboardKind::Secondary)
+            .text(&path)
+        {
+            error!("Could not copy the path {} to clipboard: {}", path, e);
+            return false;
         }
-        false
+
+        debug!("Copied the path {} to clipboard", path);
+        true
     }
 }
 

--- a/src/components/worktrees.rs
+++ b/src/components/worktrees.rs
@@ -1,5 +1,5 @@
 use crate::git;
-use arboard::{Clipboard, LinuxClipboardKind, SetExtLinux};
+use arboard::Clipboard;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
@@ -151,11 +151,7 @@ impl WorktreesComponent {
             }
         };
 
-        if let Err(e) = clipboard
-            .set()
-            .clipboard(LinuxClipboardKind::Secondary)
-            .text(&path)
-        {
+        if let Err(e) = clipboard.set().text(&path) {
             error!("Could not copy the path {} to clipboard: {}", path, e);
             return false;
         }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -9,19 +9,22 @@ use tracing::{debug, error};
 
 pub struct Repository(git2::Repository);
 impl Repository {
-    pub fn from_path(path: &str) -> Result<Self, git2::Error> {
+    pub fn from_path(path: &str, run_fetch: bool) -> Result<Self, git2::Error> {
         let repo = git2::Repository::open(path)?;
-        // git fetch --prune
-        if let Err(err) = repo.remotes().and_then(|remotes| {
-            remotes.iter().for_each(|remote| {
-                if let Err(e) = fetch_with_prune(&repo, remote.expect("Could not get remote name"))
-                {
-                    debug!("Could not fetch from remote. Error: {}", e);
-                }
-            });
-            Ok(())
-        }) {
-            debug!("Could not fetch from remotes. Error: {}", err);
+        if run_fetch {
+            // git fetch --prune
+            if let Err(err) = repo.remotes().and_then(|remotes| {
+                remotes.iter().for_each(|remote| {
+                    if let Err(e) =
+                        fetch_with_prune(&repo, remote.expect("Could not get remote name"))
+                    {
+                        debug!("Could not fetch from remote. Error: {}", e);
+                    }
+                });
+                Ok(())
+            }) {
+                debug!("Could not fetch from remotes. Error: {}", err);
+            }
         }
         Ok(Self(repo))
     }
@@ -117,11 +120,11 @@ fn fetch_with_prune(git_repo: &git2::Repository, remote_name: &str) -> Result<()
         .fetch(&refspecs, Some(&mut fetch_opts), None)?;
     Ok(())
 }
-pub fn list_repositories(path: &str) -> Vec<Repository> {
+pub fn list_repositories(path: &str, run_fetch: bool) -> Vec<Repository> {
     debug!("Listing repositories in: {}", path);
     let repositories: Vec<Repository> = find_git_dirs(Path::new(path))
         .par_iter()
-        .filter_map(|dir| match Repository::from_path(dir) {
+        .filter_map(|dir| match Repository::from_path(dir, run_fetch) {
             Ok(created_repo) => Some(created_repo),
             Err(err) => {
                 error!(


### PR DESCRIPTION
1. Support wayland clipboard manager to copy the path of the selected worktree to the clipboard [^1].
2. Add `--run-fetch` option to run `git fetch` all the repos to find out the obsolete worktrees.


[^1]: https://github.com/1Password/arboard#backend-support