### PR TITLE
feat: create worktrees from remote branches when branch name matches

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -75,7 +75,9 @@ impl App {
                         (KeyCode::Char('x'), KeyModifiers::CONTROL) => {
                             match self.worktrees_component.delete_selected_worktree() {
                                 Ok(()) => self.worktrees_component.last_error = None,
-                                Err(e) => self.worktrees_component.last_error = Some(format!("{:#}", e)),
+                                Err(e) => {
+                                    self.worktrees_component.last_error = Some(format!("{:#}", e))
+                                }
                             }
                             EventState::Consumed
                         }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -45,16 +45,40 @@ impl Repository {
             )
         })?;
 
-        let mut create_worktree_options = git2::WorktreeAddOptions::new();
-        create_worktree_options.checkout_existing(true);
-        let created_worktree = self
-            .0
-            .worktree(
-                worktree_name,
-                new_worktree_dir.as_path(),
-                Some(&create_worktree_options),
-            )
-            .wrap_err_with(|| format!("Could not create worktree '{}'", worktree_name))?;
+        let remote_branch = self.find_remote_branch_oid(worktree_name);
+
+        let created_worktree = if let Some((remote_name, oid)) = remote_branch {
+            debug!(
+                "Found remote branch '{}/{}', creating tracking branch",
+                remote_name, worktree_name
+            );
+            let commit = self
+                .0
+                .find_commit(oid)
+                .wrap_err("Could not find commit for remote branch")?;
+            let mut local_branch = self
+                .0
+                .branch(worktree_name, &commit, false)
+                .wrap_err_with(|| format!("Could not create local branch '{}'", worktree_name))?;
+            let upstream_name = format!("{}/{}", remote_name, worktree_name);
+            local_branch
+                .set_upstream(Some(&upstream_name))
+                .wrap_err_with(|| format!("Could not set upstream to '{}'", upstream_name))?;
+
+            let branch_ref = local_branch.into_reference();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.checkout_existing(true);
+            opts.reference(Some(&branch_ref));
+            self.0
+                .worktree(worktree_name, new_worktree_dir.as_path(), Some(&opts))
+                .wrap_err_with(|| format!("Could not create worktree '{}'", worktree_name))?
+        } else {
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.checkout_existing(true);
+            self.0
+                .worktree(worktree_name, new_worktree_dir.as_path(), Some(&opts))
+                .wrap_err_with(|| format!("Could not create worktree '{}'", worktree_name))?
+        };
 
         let branch = self
             .0
@@ -70,6 +94,22 @@ impl Repository {
             git_worktree: created_worktree,
             has_remote_branch: branch.upstream().is_ok(),
         })
+    }
+
+    /// Searches all remotes for a branch named `branch_name` and returns the
+    /// remote name and the OID of its tip commit, if found.
+    fn find_remote_branch_oid(&self, branch_name: &str) -> Option<(String, git2::Oid)> {
+        let remotes = self.0.remotes().ok()?;
+        for remote_name in remotes.iter().flatten() {
+            let refname = format!("refs/remotes/{}/{}", remote_name, branch_name);
+            if let Ok(reference) = self.0.find_reference(&refname) {
+                if let Ok(oid) = reference.peel_to_commit().map(|c| c.id()) {
+                    debug!("Found remote branch ref '{}' at {}", refname, oid);
+                    return Some((remote_name.to_string(), oid));
+                }
+            }
+        }
+        None
     }
 
     pub fn name(&self) -> String {
@@ -217,6 +257,140 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    /// Create a git repository with a single commit and return it along with the commit OID.
+    fn init_repo_with_commit(path: &Path) -> (git2::Repository, git2::Oid) {
+        let repo = git2::Repository::init(path).expect("Could not init repo");
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let oid = {
+            let tree_id = {
+                let mut tb = repo.treebuilder(None).unwrap();
+                let blob = repo.blob(b"hello").unwrap();
+                tb.insert("file.txt", blob, 0o100644).unwrap();
+                tb.write().unwrap()
+            };
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .expect("Could not create initial commit")
+            // tree is dropped here before repo is moved
+        };
+        (repo, oid)
+    }
+
+    #[test]
+    fn test_find_remote_branch_oid_no_remote() {
+        let repo_dir = tempdir().expect("Could not create temporary directory");
+        let (_, _) = init_repo_with_commit(repo_dir.path());
+        let repo =
+            Repository(git2::Repository::open(repo_dir.path()).expect("Could not open repo"));
+        assert!(
+            repo.find_remote_branch_oid("feature-branch").is_none(),
+            "Expected None when no remote branch exists"
+        );
+    }
+
+    #[test]
+    fn test_find_remote_branch_oid_with_remote_ref() {
+        let repo_dir = tempdir().expect("Could not create temporary directory");
+        let (git_repo, oid) = init_repo_with_commit(repo_dir.path());
+        // Simulate a fetched remote ref without actually having a remote URL
+        git_repo
+            .reference(
+                "refs/remotes/origin/feature-branch",
+                oid,
+                false,
+                "simulated fetch",
+            )
+            .expect("Could not create remote ref");
+        // Add an entry in config so git2 treats "origin" as a remote
+        {
+            let mut config = git_repo.config().unwrap();
+            config
+                .set_str("remote.origin.url", "git@github.com:example/repo.git")
+                .unwrap();
+            config
+                .set_str("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+                .unwrap();
+        }
+        drop(git_repo);
+
+        let repo =
+            Repository(git2::Repository::open(repo_dir.path()).expect("Could not open repo"));
+        let result = repo.find_remote_branch_oid("feature-branch");
+        assert!(
+            result.is_some(),
+            "Expected Some when remote branch ref exists"
+        );
+        let (remote_name, found_oid) = result.unwrap();
+        assert_eq!(remote_name, "origin");
+        assert_eq!(found_oid, oid);
+    }
+
+    #[test]
+    fn test_create_worktree_from_remote_branch() {
+        let repo_dir = tempdir().expect("Could not create repo directory");
+        let worktrees_dir = tempdir().expect("Could not create worktrees directory");
+        let (git_repo, oid) = init_repo_with_commit(repo_dir.path());
+
+        // Simulate a fetched remote ref
+        git_repo
+            .reference(
+                "refs/remotes/origin/feature-branch",
+                oid,
+                false,
+                "simulated fetch",
+            )
+            .expect("Could not create remote ref");
+        {
+            let mut config = git_repo.config().unwrap();
+            config
+                .set_str("remote.origin.url", "git@github.com:example/repo.git")
+                .unwrap();
+            config
+                .set_str("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+                .unwrap();
+        }
+        drop(git_repo);
+
+        let repo =
+            Repository(git2::Repository::open(repo_dir.path()).expect("Could not open repo"));
+        let worktree = repo
+            .create_new_worktree("feature-branch", worktrees_dir.path().to_str().unwrap())
+            .expect("Could not create worktree from remote branch");
+
+        assert!(
+            worktree.has_remote_branch,
+            "Expected has_remote_branch to be true when created from remote branch"
+        );
+
+        // Verify the local branch was created with the upstream set
+        let git_repo = git2::Repository::open(repo_dir.path()).expect("Could not open repo");
+        let branch = git_repo
+            .find_branch("feature-branch", git2::BranchType::Local)
+            .expect("Local branch should exist");
+        assert!(
+            branch.upstream().is_ok(),
+            "Local branch should track the remote branch"
+        );
+    }
+
+    #[test]
+    fn test_create_worktree_no_remote_branch() {
+        let repo_dir = tempdir().expect("Could not create repo directory");
+        let worktrees_dir = tempdir().expect("Could not create worktrees directory");
+        init_repo_with_commit(repo_dir.path());
+
+        let repo =
+            Repository(git2::Repository::open(repo_dir.path()).expect("Could not open repo"));
+        let worktree = repo
+            .create_new_worktree("local-only-branch", worktrees_dir.path().to_str().unwrap())
+            .expect("Could not create worktree");
+
+        assert!(
+            !worktree.has_remote_branch,
+            "Expected has_remote_branch to be false when no remote branch exists"
+        );
+    }
 
     #[test]
     fn test_not_git_dir() {


### PR DESCRIPTION
## Problem

When creating a new worktree, devspace always created a fresh local branch from `HEAD`, with no connection to any remote. This meant:

- If you typed a branch name that already existed on a remote (e.g. a colleague's feature branch), you'd get a brand-new local branch at HEAD instead of tracking the remote branch.
- The `✓`/`✗` remote indicator in the worktree list would always show `✗` for newly created worktrees, since the branch had no upstream.
- You'd have to manually run `git branch --set-upstream-to=origin/<branch>` after the fact.

## Solution

Before creating a worktree, `create_new_worktree` now checks all configured remotes for a branch with the same name. If a match is found, it:

1. Creates a local branch at the remote branch's tip commit (equivalent to `git checkout -b <branch> <remote>/<branch>`).
2. Sets the upstream tracking reference so the branch knows it tracks `<remote>/<branch>` (equivalent to `--track`).
3. Creates the git worktree pointed at that pre-existing local branch.

If no remote branch matches, the original behaviour is preserved — a new local branch is created from `HEAD`.

The net result: if a remote has `origin/my-feature`, typing `my-feature` in the New Worktree dialog produces a worktree whose branch already tracks `origin/my-feature` and shows `✓` immediately in the list.

## Changes

### `src/git/repository.rs`

**`find_remote_branch_oid` (new private method)**

Iterates over all configured remotes and looks up `refs/remotes/<remote>/<branch_name>`. Returns the first match as `(remote_name, commit_oid)`, or `None` if no remote has that branch. Using the OID rather than the `Reference` value avoids borrow-checker conflicts when the repo is borrowed again to create the local branch.

**`create_new_worktree` (updated)**

- Calls `find_remote_branch_oid` before touching git.
- **Remote branch found path**: creates a local branch from the OID, calls `branch.set_upstream(…)`, converts the branch to a `Reference`, and passes it as `WorktreeAddOptions::reference(…)`. This tells libgit2 to attach the worktree to the already-created branch instead of creating a new one.
- **No remote branch path**: unchanged — creates a new branch from HEAD via `WorktreeAddOptions` defaults.
- Both paths share the same post-creation check (`find_branch` + `branch.upstream().is_ok()`) to populate `Worktree::has_remote_branch`.

### Tests (4 new in `src/git/repository.rs`)

All tests use `tempfile::tempdir()` for filesystem isolation and a shared `init_repo_with_commit` helper that sets up a repo with a single commit (needed because git2 can't create branches in an empty repo).

| Test | What it verifies |
|---|---|
| `test_find_remote_branch_oid_no_remote` | Returns `None` when the repo has no remotes at all |
| `test_find_remote_branch_oid_with_remote_ref` | Returns the correct `(remote_name, oid)` when a `refs/remotes/origin/<branch>` ref exists |
| `test_create_worktree_from_remote_branch` | End-to-end: worktree is created, `has_remote_branch` is `true`, and the local branch's upstream is set |
| `test_create_worktree_no_remote_branch` | Falls back correctly — worktree is created with `has_remote_branch = false` |

> **Note on test setup**: `set_upstream` in libgit2 requires the remote to have a fetch refspec configured (`remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*`). Tests that call `create_new_worktree` with a remote branch set this config entry explicitly, since no actual network fetch is performed.

## How to test manually

1. Have a repository in `DEVSPACE_REPOS_DIR` with at least one remote that has a branch not yet checked out locally.
2. Run `cargo run` (or the built binary) with `--run-fetch` so remote refs are up to date.
3. Press `Ctrl+D`, select the repository, and type the name of the remote branch.
4. Press `Enter` — the worktree should appear immediately with a `✓` indicator.

## Based on

This PR is stacked on top of #11 (feat-improve-error-handling). The only changes relative to that PR are in `src/git/repository.rs` (the new feature logic and tests) and a minor `rustfmt` reflow in `src/app.rs`.