### PR TITLE
Add TOML config file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "devspace"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -421,8 +421,10 @@ dependencies = [
  "pretty_assertions",
  "ratatui",
  "rayon",
+ "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -1402,6 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1433,6 +1436,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -1645,6 +1657,47 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1979,6 +2032,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ ratatui = "0.29.0"
 rayon = "1.10.0"
 tracing = "0.1.41"
 tracing-error = "0.2.1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 ureq = { version = "3", features = ["json"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
-pub struct Args {
+struct RawArgs {
     /// Directory where the new git worktrees will be stored
     #[arg(
         short = 'd',
@@ -11,7 +11,7 @@ pub struct Args {
         env = "DEVSPACE_WORKTREES_DIR"
     )]
     // TODO: list worktrees from the repositories directly instead of getting the worktrees_dir from user
-    pub worktrees_dir: String,
+    worktrees_dir: Option<String>,
     /// Directory of the git repositories (colon-separated for multiple)
     #[arg(
         short = 'r',
@@ -21,23 +21,37 @@ pub struct Args {
         num_args = 1..,
         value_delimiter = ':'
     )]
-    pub repos_dirs: Vec<String>,
+    repos_dirs: Option<Vec<String>>,
 
     /// Whether to run git fetch for each repo. Default: false
-    #[arg(
-        short = 'f',
-        long = "run-fetch",
-        value_name = "BOOLEAN",
-        default_value_t = false
-    )]
+    #[arg(short = 'f', long = "run-fetch", value_name = "BOOLEAN")]
+    run_fetch: Option<bool>,
+}
+
+#[derive(Debug)]
+pub struct Args {
+    pub worktrees_dir: String,
+    pub repos_dirs: Vec<String>,
     pub run_fetch: bool,
 }
 
 impl Args {
     pub fn new() -> Self {
-        let mut args = Self::parse();
-        args.repos_dirs = args
+        let raw = RawArgs::parse();
+        let config = crate::config::Config::load().unwrap_or_default();
+
+        let worktrees_dir_raw = raw.worktrees_dir.or(config.worktrees_dir).expect(
+            "worktrees_dir must be set via --worktrees-dir, DEVSPACE_WORKTREES_DIR, or config file",
+        );
+
+        let repos_dirs_raw = raw
             .repos_dirs
+            .or(config.repos_dirs)
+            .expect("repos_dirs must be set via --repos-dir, DEVSPACE_REPOS_DIR, or config file");
+
+        let run_fetch = raw.run_fetch.or(config.run_fetch).unwrap_or(false);
+
+        let repos_dirs = repos_dirs_raw
             .iter()
             .map(|dir| {
                 std::fs::canonicalize(
@@ -49,14 +63,20 @@ impl Args {
                 .to_string()
             })
             .collect();
-        args.worktrees_dir = std::fs::canonicalize(
-            expand_tilde::expand_tilde(&args.worktrees_dir)
+
+        let worktrees_dir = std::fs::canonicalize(
+            expand_tilde::expand_tilde(&worktrees_dir_raw)
                 .expect("Could not expand the ~ in the worktrees_dir"),
         )
         .expect("Could not resolve worktrees_dir to an absolute path")
         .to_str()
         .expect("Could not convert the expanded worktrees_dir to a string")
         .to_string();
-        args
+
+        Self {
+            worktrees_dir,
+            repos_dirs,
+            run_fetch,
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,80 @@
+use color_eyre::eyre::{self, WrapErr};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Config {
+    pub worktrees_dir: Option<String>,
+    pub repos_dirs: Option<Vec<String>>,
+    pub run_fetch: Option<bool>,
+}
+
+impl Config {
+    pub fn load() -> eyre::Result<Self> {
+        let config_dir = crate::dirs::get_config_dir()?;
+        let config_path = config_dir.join("config.toml");
+        if !config_path.exists() {
+            return Ok(Self::default());
+        }
+        let contents = std::fs::read_to_string(&config_path)
+            .wrap_err_with(|| format!("Failed to read config file: {}", config_path.display()))?;
+        toml::from_str(&contents).wrap_err("Failed to parse config file")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn load_from(toml_str: &str) -> eyre::Result<Config> {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, toml_str).unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        toml::from_str(&contents).wrap_err("Failed to parse config file")
+    }
+
+    #[test]
+    fn missing_file_returns_default() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        assert!(!path.exists());
+        let config = Config::default();
+        assert!(config.worktrees_dir.is_none());
+        assert!(config.repos_dirs.is_none());
+        assert!(config.run_fetch.is_none());
+    }
+
+    #[test]
+    fn partial_config_parses() {
+        let config = load_from(r#"worktrees_dir = "/tmp/worktrees""#).unwrap();
+        assert_eq!(config.worktrees_dir.as_deref(), Some("/tmp/worktrees"));
+        assert!(config.repos_dirs.is_none());
+        assert!(config.run_fetch.is_none());
+    }
+
+    #[test]
+    fn full_config_parses() {
+        let config = load_from(
+            r#"
+worktrees_dir = "/tmp/worktrees"
+repos_dirs    = ["/home/user/src", "/home/user/work"]
+run_fetch     = true
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.worktrees_dir.as_deref(), Some("/tmp/worktrees"));
+        assert_eq!(
+            config.repos_dirs.as_deref(),
+            Some(&["/home/user/src".to_string(), "/home/user/work".to_string()][..])
+        );
+        assert_eq!(config.run_fetch, Some(true));
+    }
+
+    #[test]
+    fn invalid_toml_returns_error() {
+        let result = load_from("not valid toml ][");
+        assert!(result.is_err());
+    }
+}

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -11,13 +11,13 @@ pub fn get_data_dir() -> eyre::Result<PathBuf> {
     };
     Ok(directory)
 }
-// pub fn get_config_dir() -> eyre::Result<PathBuf> {
-//     let directory = if let Ok(s) = std::env::var("DEVSPACE_CONFIG") {
-//         PathBuf::from(s)
-//     } else if let Some(proj_dirs) = ProjectDirs::from("com", "muzomer", "devspace") {
-//         proj_dirs.config_local_dir().to_path_buf()
-//     } else {
-//         return Err(eyre::eyre!("Unable to find config directory for devspace"));
-//     };
-//     Ok(directory)
-// }
+pub fn get_config_dir() -> eyre::Result<PathBuf> {
+    let directory = if let Ok(s) = std::env::var("DEVSPACE_CONFIG") {
+        PathBuf::from(s)
+    } else if let Some(proj_dirs) = ProjectDirs::from("com", "muzomer", "devspace") {
+        proj_dirs.config_local_dir().to_path_buf()
+    } else {
+        return Err(eyre::eyre!("Unable to find config directory for devspace"));
+    };
+    Ok(directory)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 mod cli;
 mod components;
+pub mod config;
 mod dirs;
 mod git;
 mod github;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `~/.config/devspace/config.toml` (or `$DEVSPACE_CONFIG/config.toml`) as a config source for `worktrees_dir`, `repos_dirs`, and `run_fetch`
- Precedence: CLI flag > env var > config file > built-in default — existing users are unaffected
- Activates the previously commented-out `get_config_dir()` in `src/dirs.rs`
- Adds `serde` + `toml` dependencies; introduces `src/config.rs` with a `Config` struct and 4 unit tests

Example `config.toml`:
```toml
worktrees_dir = "~/worktrees"
repos_dirs    = ["~/src", "~/work"]
run_fetch     = false
```

## Test plan

- [ ] `cargo test` — all 11 tests pass (4 new in `config::tests`)
- [ ] `cargo clippy -- -D warnings` — no warnings
- [ ] `cargo fmt --check` — clean
- [ ] Run with no CLI flags but a valid config file — app starts correctly
- [ ] Run with CLI flag overriding a config value — CLI value wins
- [ ] Run with neither CLI flag nor config — descriptive panic message shown

https://claude.ai/code/session_012LTiaYxaLqxtESZxESGqpx
EOF
)